### PR TITLE
Release 1.1.0

### DIFF
--- a/IMLCGui/App.config
+++ b/IMLCGui/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
     </startup>
 </configuration>

--- a/IMLCGui/AutoUpdater.cs
+++ b/IMLCGui/AutoUpdater.cs
@@ -1,0 +1,110 @@
+﻿using Octokit;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace IMLCGui
+{
+    internal class AutoUpdater
+    {
+        private readonly GitHubClient _client;
+        public readonly Version CurrentVersion;
+
+        public Release LatestRelease { get; private set; } = null;
+        public volatile bool CheckingForUpdate = false;
+
+        public AutoUpdater()
+        {
+            this._client = new GitHubClient(new ProductHeaderValue("IMLCGui"));
+            this._client.SetRequestTimeout(TimeSpan.FromSeconds(2));
+
+            this.CurrentVersion = GetCurrentVersion();
+        }
+
+        public async Task CheckForUpdates()
+        {
+            this.LatestRelease = null;
+            this.CheckingForUpdate = true;
+
+            IReadOnlyList<Release> releases = null;
+            try
+            {
+                releases = await this._client.Repository.Release.GetAll("FarisR99", "IMLCGui");
+            }
+            catch (Exception)
+            {
+                this.CheckingForUpdate = false;
+                return;
+            }
+            if (releases == null || releases.Count == 0)
+            {
+                this.CheckingForUpdate = false;
+                return;
+            }
+
+            foreach (var release in releases)
+            {
+                if (!release.Prerelease)
+                {
+                    this.LatestRelease = release;
+                    break;
+                }
+            }
+            this.CheckingForUpdate = false;
+        }
+
+        public bool HasUpdateAvailable()
+        {
+            if (this.CurrentVersion == null) return true;
+            if (this.LatestRelease == null) return false;
+            Version latestReleaseVersion = new Version(GetLatestReleaseVersion());
+            return latestReleaseVersion.CompareTo(this.CurrentVersion) > 0;
+        }
+
+        public string GetLatestReleaseVersion()
+        {
+            if (this.LatestRelease == null) return null;
+            return this.LatestRelease.TagName;
+        }
+
+        public async Task DownloadLatest(Logger logger)
+        {
+            string latestReleaseVersion = GetLatestReleaseVersion();
+            logger.Log($"Downloading latest IMLCGui version {FormatVersion(latestReleaseVersion)}...");
+            string outputFile = await DownloadService.DownloadFileAsync(null, FormatGithubAssetUrl(latestReleaseVersion), $"IMLCGui-{latestReleaseVersion}.exe", null);
+            logger.Log($"Downloaded latest version to {outputFile}!");
+        }
+
+        public static Version GetCurrentVersion()
+        {
+            Assembly assembly = Assembly.GetExecutingAssembly();
+            if (assembly == null) return null;
+            FileVersionInfo fileVersionInfo = FileVersionInfo.GetVersionInfo(assembly.Location);
+            if (fileVersionInfo == null) return null;
+            return fileVersionInfo.ProductVersion != null
+                ? new Version(fileVersionInfo.ProductVersion)
+                : (fileVersionInfo.FileVersion != null
+                    ? new Version(fileVersionInfo.FileVersion)
+                    : null);
+        }
+
+        public static string FormatGithubAssetUrl(string tag)
+        {
+            return $"https://github.com/FarisR99/IMLCGui/releases/download/{tag}/IMLCGui.exe";
+        }
+
+        public static string FormatVersion(string version)
+        {
+            if (version == null) return null;
+            if (version.Split(new char[] { '.' }).Length == 3)
+            {
+                version += ".0";
+            }
+            return version;
+        }
+    }
+}

--- a/IMLCGui/CustomConfig.cs
+++ b/IMLCGui/CustomConfig.cs
@@ -26,12 +26,30 @@ namespace IMLCGui
             return this.list.ContainsKey(field) ? this.list[field] : null;
         }
 
+        public bool Has(string field)
+        {
+            return this.list.ContainsKey(field);
+        }
+
         public void Set(string field, string value)
         {
             if (!this.list.ContainsKey(field))
-                this.list.Add(field, value.ToString());
+            {
+                if (value != null)
+                {
+                    this.list.Add(field, value.ToString());
+                }
+            }
             else
-                this.list[field] = value.ToString();
+            {
+                if (value != null)
+                {
+                    this.list[field] = value.ToString();
+                } else
+                {
+                    this.list.Remove(field);
+                }
+            }
         }
 
         public void Save()

--- a/IMLCGui/DownloadManager.cs
+++ b/IMLCGui/DownloadManager.cs
@@ -11,11 +11,14 @@ namespace IMLCGui
     // Taken from https://stackoverflow.com/questions/49034241/canceling-webclient-download-while-waiting-for-download-to-complete
     internal class DownloadService
     {
-        public static async Task<string> DownloadFileAsync(CancellationToken cancellationToken, string url, string outputFileName, DownloadProgressChangedEventHandler handler)
+        public static async Task<string> DownloadFileAsync(CancellationToken? cancellationToken, string url, string outputFileName, DownloadProgressChangedEventHandler handler)
         {
             using (var webClient = new WebClient())
             {
-                cancellationToken.Register(webClient.CancelAsync);
+                if (cancellationToken.HasValue)
+                {
+                    cancellationToken.Value.Register(webClient.CancelAsync);
+                }
 
                 try
                 {

--- a/IMLCGui/IMLCGui.csproj
+++ b/IMLCGui/IMLCGui.csproj
@@ -10,12 +10,16 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>IMLCGui</RootNamespace>
     <AssemblyName>IMLCGui</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -28,11 +32,8 @@
     <MapFileExtensions>true</MapFileExtensions>
     <ApplicationRevision>0</ApplicationRevision>
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -61,7 +62,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="ControlzEx, Version=4.0.0.0, Culture=neutral, PublicKeyToken=69f1c32f803d307e, processorArchitecture=MSIL">
-      <HintPath>..\packages\ControlzEx.4.4.0\lib\net45\ControlzEx.dll</HintPath>
+      <HintPath>..\packages\ControlzEx.4.4.0\lib\net462\ControlzEx.dll</HintPath>
     </Reference>
     <Reference Include="ICSharpCode.SharpZipLib, Version=1.3.3.11, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
       <HintPath>..\packages\SharpZipLib.1.3.3\lib\net45\ICSharpCode.SharpZipLib.dll</HintPath>
@@ -71,6 +72,9 @@
     </Reference>
     <Reference Include="Microsoft.Xaml.Behaviors, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.19\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
+    </Reference>
+    <Reference Include="Octokit, Version=4.0.1.0, Culture=neutral, PublicKeyToken=0be8860aee462442, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octokit.4.0.1\lib\netstandard2.0\Octokit.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
@@ -98,8 +102,8 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="LatencyRow.xaml">
-      <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
     <Page Include="MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
@@ -109,6 +113,7 @@
       <DependentUpon>App.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="AutoUpdater.cs" />
     <Compile Include="CustomConfig.cs" />
     <Compile Include="DownloadManager.cs" />
     <Compile Include="FileUtils.cs" />
@@ -172,6 +177,6 @@
     <Error Condition="!Exists('..\packages\ILRepack.2.0.18\build\ILRepack.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ILRepack.2.0.18\build\ILRepack.props'))" />
   </Target>
   <Target Name="ILRepack">
-    <Exec Command="..\packages\ILRepack.2.0.18\tools\ILRepack.exe bin\Release\IMLCGui.exe /out:IMLCGui.exe bin\Release\ControlzEx.dll bin\Release\ICSharpCode.SharpZipLib.dll bin\Release\de\MahApps.Metro.resources.dll bin\Release\MahApps.Metro.dll bin\Release\Microsoft.Xaml.Behaviors.dll" />
+    <Exec Command="..\packages\ILRepack.2.0.18\tools\ILRepack.exe bin\Release\IMLCGui.exe /out:IMLCGui.exe bin\Release\ControlzEx.dll bin\Release\ICSharpCode.SharpZipLib.dll bin\Release\de\MahApps.Metro.resources.dll bin\Release\MahApps.Metro.dll bin\Release\Microsoft.Xaml.Behaviors.dll bin\Release\Octokit.dll" />
   </Target>
 </Project>

--- a/IMLCGui/MLCProcess.cs
+++ b/IMLCGui/MLCProcess.cs
@@ -154,6 +154,7 @@ namespace IMLCGui
                 }
                 process.Start();
                 this.ProcessId = process.Id;
+                process.PriorityClass = ProcessPriorityClass.AboveNormal;
             }
             return process;
         }

--- a/IMLCGui/MLCProcess.cs
+++ b/IMLCGui/MLCProcess.cs
@@ -154,7 +154,15 @@ namespace IMLCGui
                 }
                 process.Start();
                 this.ProcessId = process.Id;
-                process.PriorityClass = ProcessPriorityClass.AboveNormal;
+
+                if (Process.GetCurrentProcess().PriorityClass.CompareTo(ProcessPriorityClass.AboveNormal) >= 0)
+                {
+                    process.PriorityClass = ProcessPriorityClass.RealTime;
+                }
+                else
+                {
+                    process.PriorityClass = ProcessPriorityClass.AboveNormal;
+                }
             }
             return process;
         }

--- a/IMLCGui/MainWindow.xaml
+++ b/IMLCGui/MainWindow.xaml
@@ -56,7 +56,11 @@
                                 Height="30"
                                 HorizontalContentAlignment="Center"
                                 Name="TxtBoxQuickBandwidth"
-                                IsReadOnly="True" />
+                                ToolTip="Double click to run quick bandwidth test."
+                                IsReadOnly="True"
+                                Focusable="False"
+                                Cursor="Arrow"
+                                MouseDoubleClick="TxtBoxQuickBandwidth_DoubleClick" />
                         </Border>
 
                         <Label 
@@ -72,7 +76,11 @@
                                 Height="30"
                                 HorizontalContentAlignment="Center"
                                 Name="TxtBoxQuickLatency"
-                                IsReadOnly="True" />
+                                ToolTip="Double click to run quick latency test."
+                                IsReadOnly="True"
+                                Focusable="False"
+                                Cursor="Arrow"
+                                MouseDoubleClick="TxtBoxQuickLatency_DoubleClick" />
                         </Border>
                     </Grid>
 

--- a/IMLCGui/MainWindow.xaml
+++ b/IMLCGui/MainWindow.xaml
@@ -137,7 +137,8 @@
                                 Height="30"
                                 HorizontalContentAlignment="Center"
                                 Name="TxtBoxBandwidthAll"
-                                IsReadOnly="True" />
+                                IsReadOnly="True"
+                                Focusable="False" />
                         </Border>
 
                         <!-- Row: 3:1 Reads-Writes -->
@@ -152,7 +153,8 @@
                                 Height="30"
                                 HorizontalContentAlignment="Center"
                                 Name="TxtBoxBandwidth31"
-                                IsReadOnly="True" />
+                                IsReadOnly="True"
+                                Focusable="False" />
                         </Border>
 
                         <!-- Row: 2:1 Reads-Writes -->
@@ -167,7 +169,8 @@
                                 Height="30"
                                 HorizontalContentAlignment="Center"
                                 Name="TxtBoxBandwidth21"
-                                IsReadOnly="True" />
+                                IsReadOnly="True"
+                                Focusable="False" />
                         </Border>
 
                         <!-- Row: 1:1 Reads-Writes -->
@@ -182,7 +185,8 @@
                                 Height="30"
                                 HorizontalContentAlignment="Center"
                                 Name="TxtBoxBandwidth11"
-                                IsReadOnly="True" />
+                                IsReadOnly="True"
+                                Focusable="False" />
                         </Border>
 
                         <!-- Row: Stream-triad like -->
@@ -197,7 +201,8 @@
                                 Height="30"
                                 HorizontalContentAlignment="Center"
                                 Name="TxtBoxBandwidthStreamTriad"
-                                IsReadOnly="True" />
+                                IsReadOnly="True"
+                                Focusable="False" />
                         </Border>
                     </Grid>
 
@@ -355,7 +360,8 @@
                                 Height="30"
                                 HorizontalContentAlignment="Center"
                                 Name="TxtBoxL2Hit"
-                                IsReadOnly="True" />
+                                IsReadOnly="True"
+                                Focusable="False" />
                         </Border>
 
                         <Label 
@@ -369,7 +375,8 @@
                                 Height="30"
                                 HorizontalContentAlignment="Center"
                                 Name="TxtBoxL2HitM"
-                                IsReadOnly="True" />
+                                IsReadOnly="True"
+                                Focusable="False" />
                         </Border>
                     </Grid>
 

--- a/IMLCGui/MainWindow.xaml
+++ b/IMLCGui/MainWindow.xaml
@@ -13,6 +13,12 @@
     <Controls:MetroWindow.RightWindowCommands>
         <Controls:WindowCommands>
             <Button 
+                Content="↻"
+                Name="BtnUpdate"
+                Click="BtnUpdate_Click"
+                ToolTip="Check for updates"
+                IsEnabled="False" />
+            <Button 
                 Content="?"
                 Name="BtnHelp"
                 Click="BtnHelp_Click" />

--- a/IMLCGui/MainWindow.xaml.cs
+++ b/IMLCGui/MainWindow.xaml.cs
@@ -218,6 +218,74 @@ namespace IMLCGui
             });
         }
 
+        private void TxtBoxQuickBandwidth_DoubleClick(object sender, RoutedEventArgs e)
+        {
+            if (this._mlcProcess.ProcessId != -1)
+            {
+                return;
+            }
+            this.HandleMLCButton(() =>
+            {
+                this.TxtBoxQuickBandwidth.Text = "";
+                this.BtnQuickRun.Content = "Cancel";
+                this.ToggleOtherTabs(false);
+            },
+            "Running Intel MLC quick bandwidth test",
+            () =>
+            {
+                try
+                {
+                    RunMLCQuickProcess(this._mlcProcess.CancellationTokenSource.Token, true, "bandwidth");
+                }
+                catch (OperationCanceledException)
+                {
+                    this._mlcProcess.Kill();
+                }
+                catch (Exception ex)
+                {
+                    this._logger.Error("Failed to run Intel MLC quick bandwidth test:", ex);
+                }
+                finally
+                {
+                    this.ResetQuickRunButton();
+                }
+            });
+        }
+
+        private void TxtBoxQuickLatency_DoubleClick(object sender, RoutedEventArgs e)
+        {
+            if (this._mlcProcess.ProcessId != -1)
+            {
+                return;
+            }
+            this.HandleMLCButton(() =>
+            {
+                this.TxtBoxQuickLatency.Text = "";
+                this.BtnQuickRun.Content = "Cancel";
+                this.ToggleOtherTabs(false);
+            },
+            "Running Intel MLC quick latency test",
+            () =>
+            {
+                try
+                {
+                    RunMLCQuickProcess(this._mlcProcess.CancellationTokenSource.Token, true, "latency");
+                }
+                catch (OperationCanceledException)
+                {
+                    this._mlcProcess.Kill();
+                }
+                catch (Exception ex)
+                {
+                    this._logger.Error("Failed to run Intel MLC quick latency test:", ex);
+                }
+                finally
+                {
+                    this.ResetQuickRunButton();
+                }
+            });
+        }
+
         private void ResetQuickRunButton()
         {
             this.BtnQuickRun.Invoke(() =>

--- a/IMLCGui/MainWindow.xaml.cs
+++ b/IMLCGui/MainWindow.xaml.cs
@@ -1084,9 +1084,13 @@ namespace IMLCGui
                 }
             }
             OpenFileDialog openFileDialog = new OpenFileDialog();
+            openFileDialog.CheckFileExists = true;
+            openFileDialog.DefaultExt = ".exe";
+            openFileDialog.AddExtension = true;
+            openFileDialog.Filter = "Executable files (*.exe)|*.exe|MLC executable|mlc.exe|All files (*.*)|*.*";
             if (openFileDialog.ShowDialog() == true)
             {
-                if (!openFileDialog.CheckFileExists)
+                if (!File.Exists(openFileDialog.FileName))
                 {
                     this.ShowMessageAsync("Error", "Please select a valid exe.");
                     return;

--- a/IMLCGui/MainWindow.xaml.cs
+++ b/IMLCGui/MainWindow.xaml.cs
@@ -201,7 +201,10 @@ namespace IMLCGui
             this.ShowMessageAsync("Information",
                 $"Intel Memory Latency Checker GUI v{AutoUpdater.GetCurrentVersion()}" + Environment.NewLine +
                 Environment.NewLine +
-                "A GUI wrapper for Intel MLC made in C# by KingFaris10."
+                "A GUI wrapper for Intel MLC made in C# by KingFaris10." + Environment.NewLine +
+                Environment.NewLine +
+                "https://github.com/FarisR99/IMLCGui" + Environment.NewLine +
+                "https://kingfaris.co.uk/"
             );
         }
 

--- a/IMLCGui/Properties/AssemblyInfo.cs
+++ b/IMLCGui/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.1.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]

--- a/IMLCGui/Properties/Settings.Designer.cs
+++ b/IMLCGui/Properties/Settings.Designer.cs
@@ -8,21 +8,17 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace IMLCGui.Properties
-{
-
-
+namespace IMLCGui.Properties {
+    
+    
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "11.0.0.0")]
-    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase
-    {
-
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.3.0.0")]
+    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
+        
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
-
-        public static Settings Default
-        {
-            get
-            {
+        
+        public static Settings Default {
+            get {
                 return defaultInstance;
             }
         }

--- a/IMLCGui/packages.config
+++ b/IMLCGui/packages.config
@@ -1,8 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ControlzEx" version="4.4.0" targetFramework="net46" />
+  <package id="ControlzEx" version="4.4.0" targetFramework="net462" />
   <package id="ILRepack" version="2.0.18" targetFramework="net46" />
-  <package id="MahApps.Metro" version="2.4.9" targetFramework="net46" />
+  <package id="MahApps.Metro" version="2.4.9" targetFramework="net462" />
   <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.19" targetFramework="net46" />
+  <package id="Octokit" version="4.0.1" targetFramework="net462" />
   <package id="SharpZipLib" version="1.3.3" targetFramework="net46" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Lightweight GUI wrapper for [Intel Memory Latency Checker](https://www.intel.com
 Requires a Windows system with at least .NET Framework 4.6.
 
 ## Usage
-1. Either download the compiled executable from [Releases](../../releases), or compile this project yourself (I would recommend using Visual Studio).
+1. Either download the compiled executable from [Releases](../../releases), or compile this project yourself (Visual Studio and `msbuild /t:ILRepack`).
 2. Move the executable file to its own directory as it creates a configuration file and a log file.
 4. Run the application as an administrator (not required but strongly recommended)
 5. Click the Configure tab and either hit Download (attempts to download and extract Intel MLC to the directory MLC is running from) or Browse to locate your existing download of Intel MLC. This step is not necessary if you move your existing MLC files to the same directory that this executable is located in.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Lightweight GUI wrapper for [Intel Memory Latency Checker](https://www.intel.com
 ![IMLCGui](https://user-images.githubusercontent.com/3731915/149428525-a9370dcd-330b-40fa-a24e-979067ba0647.png)
 
 ## Compatibility
-Requires a Windows system with at least .NET Framework 4.6.
+Requires a Windows system with at least .NET Framework 4.6.2.
 
 ## Usage
 1. Either download the compiled executable from [Releases](../../releases), or compile this project yourself (Visual Studio and `msbuild /t:ILRepack`).


### PR DESCRIPTION
# Additions
- Double click the Bandwidth or Latency boxes in the Quick tab to run these tests individually
- Update checker

# Changes
- Built against .NET Framework 4.6.2
- Runs mlc.exe with an `Above Normal` priority. If you run the GUI with `Above Normal` priority or higher, mlc.exe will run at `Realtime` priority
- Minor UI enhancements