### PR TITLE
Release 1.2.0 - Patch 1

### DIFF
--- a/IMLCGui/MLCProcess.cs
+++ b/IMLCGui/MLCProcess.cs
@@ -65,7 +65,12 @@ namespace IMLCGui
 
         public static string GenerateCacheArguments(string mlcVersion)
         {
-            return "--c2c_latency";
+            string mlcArguments = "--c2c_latency";
+            if ("v3.10".Equals(mlcVersion))
+            {
+                mlcArguments += " -e0";
+            }
+            return mlcArguments;
         }
 
         public static string GenerateLatencyArguments(string mlcVersion, string injectDelayOverride)
@@ -74,6 +79,10 @@ namespace IMLCGui
             if (injectDelayOverride != null)
             {
                 mlcArguments += " -d" + injectDelayOverride;
+            }
+            if ("v3.10".Equals(mlcVersion))
+            {
+                mlcArguments += " -e0";
             }
             return mlcArguments;
         }

--- a/IMLCGui/Properties/AssemblyInfo.cs
+++ b/IMLCGui/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.1.0")]
-[assembly: AssemblyFileVersion("1.1.1.0")]
+[assembly: AssemblyVersion("1.2.0.0")]
+[assembly: AssemblyFileVersion("1.2.0.0")]


### PR DESCRIPTION
# Bug Fixes
- Run the latency test with `-e0` when using MLC v3.10.