### PR TITLE
Release 1.2.4

### DIFF
--- a/IMLCGui/MLCProcess.cs
+++ b/IMLCGui/MLCProcess.cs
@@ -8,7 +8,7 @@ namespace IMLCGui
     internal class MLCProcess
     {
         private static readonly string VERSION_STRING_PREFIX = "Memory Latency Checker - ";
-        private static readonly List<string> NEW_VERSIONS = new List<string> { "v3.10", "v3.11", "v3.11b" };
+        private static readonly List<string> NEW_VERSIONS = new List<string> { "v3.10", "v3.11", "v3.11b", "v3.12" };
 
         public static async Task<string> GetMLCVersion(string processPath)
         {

--- a/IMLCGui/Properties/AssemblyInfo.cs
+++ b/IMLCGui/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.3.0")]
-[assembly: AssemblyFileVersion("1.2.3.0")]
+[assembly: AssemblyVersion("1.2.4.0")]
+[assembly: AssemblyFileVersion("1.2.4.0")]


### PR DESCRIPTION
# Bug Fixes
- Fix MLC CLI runtime arg when using MLC v3.12. PR #19 added support for MLC v3.12, but the exe was not run with `-e0`.
